### PR TITLE
#2 Include wabbajack file.

### DIFF
--- a/3090.wabbajack.meta.json
+++ b/3090.wabbajack.meta.json
@@ -1,1 +1,1 @@
-{"Hash":"leqUUS/qv/U=","Size":5875204,"NumberOfArchives":9,"SizeOfArchives":22504811779,"NumberOfInstalledFiles":17508,"SizeOfInstalledFiles":27857499603}
+{"Hash":"1DLpRCm7KfU=","Size":5876071,"NumberOfArchives":9,"SizeOfArchives":22504811779,"NumberOfInstalledFiles":17508,"SizeOfInstalledFiles":27857500242}


### PR DESCRIPTION
Decided to always also sync wabbajack file although it's binary file. There's lot of room in Github and if we run out, then I'll go through the repositoy and delete all old wabbajack files. For now it's great way to keep things revisioned.